### PR TITLE
bugfix - getting correct number of test failures

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -14,7 +14,14 @@ jobs:
         path: "tester"
         import-time: "5"
         test-timeout: "45"
-        minimum-pass: "0.8"
+        minimum-pass: "0.7"
+    - uses: ./
+      continue-on-error: true
+      with:
+        version: "3.2.2"
+        path: "tester"
+        test-timeout: "2"
+        minimum-pass: "0.7"
     - uses: ./
       continue-on-error: true
       with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,14 +59,20 @@ rm -f ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}.zip
 # parsing test output to fill test count and pass count variables
 TESTS=0
 PASSED=0
-teststring="Tests:"
+FAILED=0
+passingstring="Passing asserts:"
+failingstring="Failing asserts:"
 passedstring="Tests finished"
 while read line; do
     # check for line that starts with Passed:
-    if [[ $line =~ ^$teststring ]] ; then
+    if [[ $line =~ ^$passingstring ]] ; then
         # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
         temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
-        TESTS=${temp//[!0-9]/}
+        PASSED=${temp//[!0-9]/}
+    elif [[ $line =~ ^$failingstring ]] ; then
+        # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
+        temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
+        FAILED=${temp//[!0-9]/}
     elif [[ $line == *$passedstring* ]] ; then
         # heavily depends on the number passed being the first argument
         # in the line that has 'Tests finished', 
@@ -74,7 +80,7 @@ while read line; do
         temp=$(echo $line | sed 's/ .*//')
         # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
         temp=$(echo $temp | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
-        PASSED=${temp//[!0-9]/}
+        TESTS=`echo "$PASSED+$FAILED"|bc -l`
     fi
 done <<< "$(echo "${outp}")"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,6 +82,7 @@ while read line; do
     elif [[ $temp == *"$possible_tested_string"* ]] ; then
         if [[ $temp == *"$test_ran_string"* ]] ; then
             PASSED=$((PASSED+1))
+            echo "found hidden test"
         fi
     elif [[ $temp =~ ^$test_failed_string ]] ; then
         PASSED=$((PASSED-1))

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,10 +46,10 @@ set +e
 # run tests
 if [ IS_MONO = "true" ] ; then
 # need to init the imports
-    outp0=$(timeout ${IMPORT_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}/${FULL_GODOT_NAME}.64 -e)
+    outp0=$(timeout ${IMPORT_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}/${FULL_GODOT_NAME}.64 -e 2>&1)
     outp=$(timeout ${TEST_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}/${FULL_GODOT_NAME}.64 -s addons/gut/gut_cmdln.gd -gdir=res://test -ginclude_subdirs -gexit 2>&1)
 else
-    outp0=$(timeout ${IMPORT_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION} -e)
+    outp0=$(timeout ${IMPORT_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION} -e 2>&1)
     outp=$(timeout ${TEST_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION} -s addons/gut/gut_cmdln.gd -gdir=res://test -ginclude_subdirs -gexit 2>&1)
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,7 +64,7 @@ teststring="Tests:"
 # a line that starts with "* test"
 # versus the number of tests total 
 test_contains_string="test ~ test"
-test_ran_string="* test"
+test_ran_string=" test"
 possible_tested_string="waiting"
 test_failed_string="- test"
 while read line; do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,6 +59,9 @@ rm -f ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}.zip
 # parsing test output to fill test count and pass count variables
 TESTS=0
 FAILED=0
+
+script_error_fns=()
+
 teststring="Tests:"
 # new solution, need to count number of tests that were run e.g. 
 # a line that starts with "* test"
@@ -73,11 +76,19 @@ while read line; do
     # echo LINE: $temp
     if [[ $temp =~ ^$script_error ]] ; then
         FAILED=$((FAILED+1))
+        script_error_fns+=( $(echo $temp | awk '{print $3}') )
     elif [[ $temp =~ ^$teststring ]] ; then
         # temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         TESTS=${temp//[!0-9]/}
     elif [[ $temp =~ ^$test_failed_string ]] ; then
         FAILED=$((FAILED+1))
+        match_fn_name=$(echo $temp | awk '{print $2}')
+        for i in "${array[@]}" ; do
+            if [ "$i" == "$yourValue" ] ; then
+                FAILED=$((FAILED-1))
+                break
+            fi
+        done
     fi
 done <<< "$(echo "${outp}")"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,18 +63,19 @@ teststring="Tests:"
 # new solution, need to count number of tests that were run e.g. 
 # a line that starts with "* test"
 # versus the number of tests total 
-
+test_contains_string="test ~ test"
 test_ran_string="* test"
 possible_tested_string="waiting"
 test_failed_string="- test"
 while read line; do
     # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
     temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
-    echo LINE: $temp
+    # can see with below line all the extra characters that echo ignores
+    # echo LINE: $temp
     if [[ $temp =~ ^$teststring ]] ; then    
         # temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         TESTS=${temp//[!0-9]/}
-    elif [[ $temp =~ ^$test_ran_string ]] ; then
+    elif [[ $temp == *"$test_contains_string"* ]] ; then
         # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
         #temp=$(echo $temp | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         PASSED=$((PASSED+1))

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,7 +79,7 @@ while read line; do
         # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
         #temp=$(echo $temp | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         PASSED=$((PASSED+1))
-    elif [[ $temp =~ ^$possible_tested_string ]] ; then
+    elif [[ $temp == *"$possible_tested_string"* ]] ; then
         if [[ $temp == *"$test_ran_string"* ]] ; then
             PASSED=$((PASSED+1))
         fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,7 +76,9 @@ while read line; do
     # echo LINE: $temp
     if [[ $temp =~ ^$script_error ]] ; then
         FAILED=$((FAILED+1))
-        script_error_fns+=( $(echo $temp | awk '{print $3}') )
+        t_script_err_str=$(echo $temp | awk '{print $3}')
+        t_script_err_str=${t_script_err_str%?}
+        script_error_fns+=( $t_script_err_str )
     elif [[ $temp =~ ^$teststring ]] ; then
         # temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         TESTS=${temp//[!0-9]/}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -114,8 +114,6 @@ else
     fi
 fi
 
-
-
 if [ "$endmsg" != "" ] ; then
     echo -e "${endmsg}"
     echo -e "Note: Tests may appear to pass on SCRIPT ERROR, but they were just ignored by GUT"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,20 +59,14 @@ rm -f ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}.zip
 # parsing test output to fill test count and pass count variables
 TESTS=0
 PASSED=0
-FAILED=0
-passingstring="Passing asserts:"
-failingstring="Failing asserts:"
+teststring="Tests:"
 passedstring="Tests finished"
 while read line; do
     # check for line that starts with Passed:
-    if [[ $line =~ ^$passingstring ]] ; then
+    if [[ $line =~ ^$teststring ]] ; then
         # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
         temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
-        PASSED=${temp//[!0-9]/}
-    elif [[ $line =~ ^$failingstring ]] ; then
-        # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
-        temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
-        FAILED=${temp//[!0-9]/}
+        TESTS=${temp//[!0-9]/}
     elif [[ $line == *$passedstring* ]] ; then
         # heavily depends on the number passed being the first argument
         # in the line that has 'Tests finished', 
@@ -80,7 +74,7 @@ while read line; do
         temp=$(echo $line | sed 's/ .*//')
         # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
         temp=$(echo $temp | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
-        TESTS=`echo "$PASSED+$FAILED"|bc -l`
+        PASSED=${temp//[!0-9]/}
     fi
 done <<< "$(echo "${outp}")"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,15 +64,16 @@ teststring="Tests:"
 # a line that starts with "* test"
 # versus the number of tests total 
 test_failed_string="- test"
+script_error="SCRIPT ERROR"
 
 while read line; do
     # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
     temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
     # can see with below line all the extra characters that echo ignores
-    echo LINE: $temp
-    if [[ $temp == *"SCRIPT ERROR"* ]] ; then
+    # echo LINE: $temp
+    if [[ $temp =~ ^$script_error ]] ; then
         FAILED=$((FAILED+1))
-    elif [[ $temp =~ ^$teststring ]] ; then    
+    elif [[ $temp =~ ^$teststring ]] ; then
         # temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         TESTS=${temp//[!0-9]/}
     elif [[ $temp =~ ^$test_failed_string ]] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,10 +47,10 @@ set +e
 if [ IS_MONO = "true" ] ; then
 # need to init the imports
     outp0=$(timeout ${IMPORT_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}/${FULL_GODOT_NAME}.64 -e)
-    outp=$(timeout ${TEST_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}/${FULL_GODOT_NAME}.64 -s addons/gut/gut_cmdln.gd -gdir=res://test -ginclude_subdirs -gexit)
+    outp=$(timeout ${TEST_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}/${FULL_GODOT_NAME}.64 -s addons/gut/gut_cmdln.gd -gdir=res://test -ginclude_subdirs -gexit 2>&1)
 else
     outp0=$(timeout ${IMPORT_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION} -e)
-    outp=$(timeout ${TEST_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION} -s addons/gut/gut_cmdln.gd -gdir=res://test -ginclude_subdirs -gexit)
+    outp=$(timeout ${TEST_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION} -s addons/gut/gut_cmdln.gd -gdir=res://test -ginclude_subdirs -gexit 2>&1)
 fi
 
 rm -rf ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}
@@ -64,21 +64,15 @@ teststring="Tests:"
 # a line that starts with "* test"
 # versus the number of tests total 
 test_failed_string="- test"
-errors=$(</tmp/Error)
-# failing a test per script error found, may be incorrect
-while read line; do
-    echo LINE: $line
-    if [[ $line == *"SCRIPT ERROR" ]] ; then
-        FAILED=$((FAILED+1))
-    fi
-done <<< "$(echo "${errors}")"
 
 while read line; do
     # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
     temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
     # can see with below line all the extra characters that echo ignores
-    # echo LINE: $temp
-    if [[ $temp =~ ^$teststring ]] ; then    
+    echo LINE: $temp
+    if [[ $temp == *"SCRIPT ERROR"* ]] ; then
+        FAILED=$((FAILED+1))
+    elif [[ $temp =~ ^$teststring ]] ; then    
         # temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         TESTS=${temp//[!0-9]/}
     elif [[ $temp =~ ^$test_failed_string ]] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,14 +64,14 @@ teststring="Tests:"
 # a line that starts with "* test"
 # versus the number of tests total 
 test_failed_string="- test"
-
+errors=$(</tmp/Error)
 # failing a test per script error found, may be incorrect
 while read line; do
     echo LINE: $line
     if [[ $line == *"SCRIPT ERROR" ]] ; then
         FAILED=$((FAILED+1))
     fi
-done <<< "$(echo "${outp0}")"
+done <<< "$(echo "${errors}")"
 
 while read line; do
     # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,23 +58,27 @@ rm -f ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}.zip
 
 # parsing test output to fill test count and pass count variables
 TESTS=0
-PASSED=0
+FAILED=0
 teststring="Tests:"
-passedstring="Tests finished"
+# new solution, need to count number of tests that were run e.g. 
+# a line that starts with "* test"
+# versus the number of tests total 
+
+failedstring="- test"
 while read line; do
     # check for line that starts with Passed:
     if [[ $line =~ ^$teststring ]] ; then
         # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
         temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         TESTS=${temp//[!0-9]/}
-    elif [[ $line == *$passedstring* ]] ; then
+    elif [[ $line =~ ^$failedstring ]] ; then
         # heavily depends on the number passed being the first argument
         # in the line that has 'Tests finished', 
-        # the only reliable count of passed tests
-        temp=$(echo $line | sed 's/ .*//')
+        # the only reliable count of passed asserts
+        #temp=$(echo $line | sed 's/ .*//')
         # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
-        temp=$(echo $temp | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
-        PASSED=${temp//[!0-9]/}
+        #temp=$(echo $temp | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
+        (( ++FAILED ))
     fi
 done <<< "$(echo "${outp}")"
 
@@ -86,7 +90,7 @@ if [ "$TESTS" -eq "0" ] ; then
     exitval=1
     endmsg="Tests failed due to timeout or there were no tests to run\n"
 else
-    passrate=`echo "scale=3; $PASSED/$TESTS"|bc -l`
+    passrate=`echo "scale=3; ($TESTS-$FAILED)/$TESTS"|bc -l`
     
     if (( $(echo "$passrate >= $MINIMUM_PASSRATE" |bc -l) )); then
         exitval=0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,24 +68,20 @@ test_ran_string="* test"
 possible_tested_string="waiting"
 test_failed_string="- test"
 while read line; do
-    # check for line that starts with Passed:
-    if [[ $line =~ ^$teststring ]] ; then
-        # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
-        temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
+    # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
+    temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
+    if [[ $temp =~ ^$teststring ]] ; then    
+        # temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         TESTS=${temp//[!0-9]/}
-    elif [[ $line =~ ^$test_ran_string ]] ; then
-        # heavily depends on the number passed being the first argument
-        # in the line that has 'Tests finished', 
-        # the only reliable count of passed asserts
-        #temp=$(echo $line | sed 's/ .*//')
+    elif [[ $temp =~ ^$test_ran_string ]] ; then
         # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
         #temp=$(echo $temp | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         PASSED=$((PASSED+1))
-    elif [[ $line =~ ^$possible_tested_string ]] ; then
-        if [[ $line == *"$test_ran_string"* ]] ; then
+    elif [[ $temp =~ ^$possible_tested_string ]] ; then
+        if [[ $temp == *"$test_ran_string"* ]] ; then
             PASSED=$((PASSED+1))
         fi
-    elif [[ $line =~ ^$test_failed_string ]] ; then
+    elif [[ $temp =~ ^$test_failed_string ]] ; then
         PASSED=$((PASSED-1))
     fi
 done <<< "$(echo "${outp}")"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,8 +83,10 @@ while read line; do
     elif [[ $temp =~ ^$test_failed_string ]] ; then
         FAILED=$((FAILED+1))
         match_fn_name=$(echo $temp | awk '{print $2}')
-        for i in "${array[@]}" ; do
-            if [ "$i" == "$yourValue" ] ; then
+        echo $script_error_fns
+        echo $match_fn_name
+        for i in "${script_error_fns[@]}" ; do
+            if [ "$i" == "$match_fn_name" ] ; then
                 FAILED=$((FAILED-1))
                 break
             fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,13 +80,10 @@ while read line; do
         t_script_err_str=${t_script_err_str%?}
         script_error_fns+=( $t_script_err_str )
     elif [[ $temp =~ ^$teststring ]] ; then
-        # temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         TESTS=${temp//[!0-9]/}
     elif [[ $temp =~ ^$test_failed_string ]] ; then
         FAILED=$((FAILED+1))
         match_fn_name=$(echo $temp | awk '{print $2}')
-        echo $script_error_fns
-        echo $match_fn_name
         for i in "${script_error_fns[@]}" ; do
             if [ "$i" == "$match_fn_name" ] ; then
                 FAILED=$((FAILED-1))
@@ -98,6 +95,9 @@ done <<< "$(echo "${outp}")"
 
 # ensuring failing enough tests / being timed out cause failure for
 # the action
+echo "${outp0}"
+echo "${outp}"
+
 passrate=".0"
 endmsg=""
 if [ "$TESTS" -eq "0" ] ; then
@@ -105,7 +105,7 @@ if [ "$TESTS" -eq "0" ] ; then
     endmsg="Tests failed due to timeout or there were no tests to run\n"
 else
     passrate=`echo "scale=3; ($TESTS-$FAILED)/$TESTS"|bc -l`
-    
+    echo -e "\n${passrate} pass rate\n"
     if (( $(echo "$passrate >= $MINIMUM_PASSRATE" |bc -l) )); then
         exitval=0
     else
@@ -114,10 +114,7 @@ else
     fi
 fi
 
-# messages to help debug for end user
-echo "${outp0}"
-echo "${outp}"
-echo -e "\n${passrate} pass rate\n"
+
 
 if [ "$endmsg" != "" ] ; then
     echo -e "${endmsg}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,6 +70,7 @@ test_failed_string="- test"
 while read line; do
     # credit : https://stackoverflow.com/questions/17998978/removing-colors-from-output
     temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
+    echo LINE: $temp
     if [[ $temp =~ ^$teststring ]] ; then    
         # temp=$(echo $line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g')
         TESTS=${temp//[!0-9]/}

--- a/tester/test/unit/test_script.gd
+++ b/tester/test/unit/test_script.gd
@@ -34,6 +34,14 @@ func test_assert_copy3():
 func test_assert_copy4():
 	assert_true(1 < 2)
 
+func test_load_scene1() ->void:
+	scene = main_scene.instance()
+	current_scene.add_child(scene)
+	# should fail pretty hard
+	main_scene.blargh()
+	assert_true(11 < 4)
+	assert_eq(scene.name, current_scene.get_node(scene.name).name)
+
 func test_assert_is_wrong():
 	assert_true(1 > 2)
 

--- a/tester/test/unit/test_script.gd
+++ b/tester/test/unit/test_script.gd
@@ -43,4 +43,5 @@ func test_load_scene() ->void:
 	current_scene.add_child(scene)
 	# should fail pretty hard
 	main_scene.blargh()
+	assert_true(11 < 4)
 	assert_eq(scene.name, current_scene.get_node(scene.name).name)

--- a/tester/test/unit/test_script.gd
+++ b/tester/test/unit/test_script.gd
@@ -27,6 +27,8 @@ func test_assert_copy3():
 	assert_true(1 < 2)
 
 func test_assert_copy4():
+	assert_eq(1, 2)
+	assert_true(2 < 1)
 	assert_true(1 < 2)
 
 func test_assert_is_wrong():
@@ -34,7 +36,7 @@ func test_assert_is_wrong():
 
 func test_wait_test():
 	yield(get_tree().create_timer(6.0), "timeout")
-	assert_true(1 < 3)	
+	assert_true(1 < 3)
 
 func test_load_scene() ->void:
 	scene = main_scene.instance()

--- a/tester/test/unit/test_script.gd
+++ b/tester/test/unit/test_script.gd
@@ -19,6 +19,11 @@ func test_assert_copy():
 
 func test_assert_copy1():
 	assert_true(1 < 2)
+	assert_true(3 < 2)
+	assert_true(1 < 2)
+	assert_true(2 < 2)
+	assert_true(1 < 2)
+	assert_true(1 < 2)
 
 func test_assert_copy2():
 	assert_true(1 < 2)

--- a/tester/test/unit/test_script.gd
+++ b/tester/test/unit/test_script.gd
@@ -37,9 +37,10 @@ func test_assert_copy4():
 func test_load_scene1() ->void:
 	scene = main_scene.instance()
 	current_scene.add_child(scene)
+	assert_true(11 < 4)
 	# should fail pretty hard
 	main_scene.blargh()
-	assert_true(11 < 4)
+	
 	assert_eq(scene.name, current_scene.get_node(scene.name).name)
 
 func test_assert_is_wrong():

--- a/tester/test/unit/test_script.gd
+++ b/tester/test/unit/test_script.gd
@@ -27,8 +27,6 @@ func test_assert_copy3():
 	assert_true(1 < 2)
 
 func test_assert_copy4():
-	assert_eq(1, 2)
-	assert_true(2 < 1)
 	assert_true(1 < 2)
 
 func test_assert_is_wrong():
@@ -36,7 +34,7 @@ func test_assert_is_wrong():
 
 func test_wait_test():
 	yield(get_tree().create_timer(6.0), "timeout")
-	assert_true(1 < 3)
+	assert_true(1 < 3)	
 
 func test_load_scene() ->void:
 	scene = main_scene.instance()

--- a/tester/test/unit/test_two.gd
+++ b/tester/test/unit/test_two.gd
@@ -1,0 +1,26 @@
+extends "res://addons/gut/test.gd"
+
+const main_scene = preload("res://main.tscn")
+var scene
+var current_scene
+
+func before_all():
+	var root = get_tree().get_root()
+	current_scene = root.get_child(root.get_child_count() -1)
+
+func test_another():
+	assert_true(1 < 2)
+
+func test_2():
+	assert_true(1 < 2)
+
+func test_again():
+	assert_true(1 < 2)
+
+func test_it():
+	assert_true(1 < 2)
+	assert_true(1 < 2)
+	assert_true(1 < 2)
+	assert_true(1 < 2)
+	assert_true(1 < 2)
+	assert_true(1 < 2)


### PR DESCRIPTION
 when using multiple failing asserts in a single test function or having script errors, will ensure passing
requires tests to start with test, mirroring the GUT default