### PR TITLE
add support for non stable godot releases

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -34,4 +34,9 @@ jobs:
       with:
         version: "3.2.2"
         path: "tester"
-        
+    - uses: ./
+      continue-on-error: true
+      with:
+        version: "3.4"
+        release_type: "rc2"
+        path: "tester"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ jobs:
       with:
         # required
         version: "3.2.2"
+        # the type of release of godot that the tests should be run with
+        release_type: "rc2"
         is-mono: "true"
         # the folder with your projects.godot file in it
         path: "tester"

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Your Godot version number e.g. 3.2.2"
     required: true
     default: "3.2.2"
+  release_type:
+    description: "Your Godot release type e.g. rc2, beta3"
+    required: false
+    default: "stable"
   path:
     description: "Give relative path to your project.godot, if not in top level of repo"
     required: false
@@ -31,6 +35,7 @@ runs:
   image: 'Dockerfile'
   args:
   - ${{ inputs.version }}
+  - ${{ inputs.release_type }}
   - ${{ inputs.path }}
   - ${{ inputs.is-mono }}
   - ${{ inputs.import-time }}
@@ -38,5 +43,5 @@ runs:
   - ${{ inputs.minimum-pass }}
 
 branding:
-  icon: 'chevron-right'  
+  icon: 'chevron-right'
   color: 'green'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,24 +4,31 @@
 set -e
 
 GODOT_VERSION=$1
-PROJECT_DIRECTORY=$2
-IS_MONO=$3
-IMPORT_TIME=$4
-TEST_TIME=$5
-MINIMUM_PASSRATE=$6
+RELEASE_TYPE=$2
+PROJECT_DIRECTORY=$3
+IS_MONO=$4
+IMPORT_TIME=$5
+TEST_TIME=$6
+MINIMUM_PASSRATE=$7
 GODOT_SERVER_TYPE="headless"
 CUSTOM_DL_PATH="~/custom_dl_folder"
 
+if [ "$RELEASE_TYPE" = "stable" ] ; then
+    DL_PATH_SUFFIX=""
+else
+    DL_PATH_SUFFIX="/${RELEASE_TYPE}"
+fi
+
 # if download places changes, will need updates to this if/else
-if [ IS_MONO = "true" ] ; then 
-    GODOT_RELEASE_TYPE="stable_mono"
-    DL_PATH_EXTENSION=${GODOT_VERSION}/mono/
+if [ IS_MONO = "true" ] ; then
+    GODOT_RELEASE_TYPE="${RELEASE_TYPE}_mono"
+    DL_PATH_EXTENSION="${GODOT_VERSION}${DL_PATH_SUFFIX}/mono/"
     GODOT_EXTENSION="_64"
     # this is a folder for mono versions
     FULL_GODOT_NAME=Godot_v${GODOT_VERSION}-${GODOT_RELEASE_TYPE}_linux_${GODOT_SERVER_TYPE}
 else
-    GODOT_RELEASE_TYPE="stable"
-    DL_PATH_EXTENSION=${GODOT_VERSION}/
+    GODOT_RELEASE_TYPE="${RELEASE_TYPE}"
+    DL_PATH_EXTENSION="${GODOT_VERSION}${DL_PATH_SUFFIX}/"
     GODOT_EXTENSION=".64"
     FULL_GODOT_NAME=Godot_v${GODOT_VERSION}-${GODOT_RELEASE_TYPE}_linux_${GODOT_SERVER_TYPE}
 fi
@@ -34,8 +41,9 @@ mkdir -p ${CUSTOM_DL_PATH}
 rm -rf ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}
 rm -f ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}.zip
 # setup godot environment
-echo "downloading godot ..."
-yes | wget -q https://downloads.tuxfamily.org/godotengine/${DL_PATH_EXTENSION}${FULL_GODOT_NAME}${GODOT_EXTENSION}.zip -P ${CUSTOM_DL_PATH}
+DL_URL="https://downloads.tuxfamily.org/godotengine/${DL_PATH_EXTENSION}${FULL_GODOT_NAME}${GODOT_EXTENSION}.zip"
+echo "downloading godot from ${DL_URL} ..."
+yes | wget -q ${DL_URL} -P ${CUSTOM_DL_PATH}
 mkdir -p ~/.cache
 mkdir -p ~/.config/godot
 echo "unzipping ..."
@@ -63,9 +71,9 @@ FAILED=0
 script_error_fns=()
 
 teststring="Tests:"
-# new solution, need to count number of tests that were run e.g. 
+# new solution, need to count number of tests that were run e.g.
 # a line that starts with "* test"
-# versus the number of tests total 
+# versus the number of tests total
 test_failed_string="- test"
 script_error="SCRIPT ERROR"
 


### PR DESCRIPTION
adds support for non stable godot releases by providing an option to set release_type to something like `rc2` or `beta4`