### PR TITLE
make test dir configurable

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -15,6 +15,7 @@ jobs:
         import-time: "5"
         test-timeout: "45"
         minimum-pass: "0.7"
+        test-dir: "res://test"
     - uses: ./
       continue-on-error: true
       with:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ jobs:
         # the ratio of tests that must pass for this action to pass
         # e.g. 0.6 means 60% of your tests must pass
         minimum-pass: "0.6"
+        # the directory containing Gut tests
+        test-dir: "res://test"
 
 ~~~~
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "Decimal value for minimum passing score e.g. if 88% of tests pass and minimum-pass is 0.8, then action passes."
     required: false
     default: "0.99"
+  test-dir:
+    description: "Directory containing Gut tests"
+    required: false
+    default: "res://test"
 
 runs:
   using: 'docker'
@@ -41,6 +45,7 @@ runs:
   - ${{ inputs.import-time }}
   - ${{ inputs.test-timeout }}
   - ${{ inputs.minimum-pass }}
+  - ${{ inputs.test-dir }}
 
 branding:
   icon: 'chevron-right'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ IS_MONO=$4
 IMPORT_TIME=$5
 TEST_TIME=$6
 MINIMUM_PASSRATE=$7
+TEST_DIR=$8
 GODOT_SERVER_TYPE="headless"
 CUSTOM_DL_PATH="~/custom_dl_folder"
 
@@ -55,10 +56,10 @@ set +e
 if [ IS_MONO = "true" ] ; then
 # need to init the imports
     outp0=$(timeout ${IMPORT_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}/${FULL_GODOT_NAME}.64 -e 2>&1)
-    outp=$(timeout ${TEST_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}/${FULL_GODOT_NAME}.64 -s addons/gut/gut_cmdln.gd -gdir=res://test -ginclude_subdirs -gexit 2>&1)
+    outp=$(timeout ${TEST_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}/${FULL_GODOT_NAME}.64 -s addons/gut/gut_cmdln.gd -gdir=${TEST_DIR} -ginclude_subdirs -gexit 2>&1)
 else
     outp0=$(timeout ${IMPORT_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION} -e 2>&1)
-    outp=$(timeout ${TEST_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION} -s addons/gut/gut_cmdln.gd -gdir=res://test -ginclude_subdirs -gexit 2>&1)
+    outp=$(timeout ${TEST_TIME} ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION} -s addons/gut/gut_cmdln.gd -gdir=${TEST_DIR} -ginclude_subdirs -gexit 2>&1)
 fi
 
 rm -rf ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}


### PR DESCRIPTION
I prefer to have a `tests` directory instead of a `test` directory.

This PR adds a new param `test-dir` that is defaulted to `res://test` to maintain compatibility with previous versions.

<img width="526" alt="Capture" src="https://user-images.githubusercontent.com/7788341/139708842-b0b82863-0c2d-455d-baa3-3836348bbc10.png">
