### PR TITLE
fix for GUT 7.3.0

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -126,8 +126,8 @@ check_by_assert() {
             fails=$(echo $temp | awk '{print $3}')
             FAILED=$((FAILED + fails))
             TESTS=$((TESTS + FAILED + passes))
-            echo "total failed asserts $FAILED"
-            echo "total asserts $TESTS"
+            echo "total failed tests $FAILED"
+            echo "total tests $TESTS"
             echo
             echo
             break

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -95,7 +95,7 @@ check_by_test() {
 check_by_assert() {
     script_error_fns=()
 
-    teststring="Tests:"
+    teststring="Totals"
     script_error="SCRIPT ERROR"
 
     test_set=0
@@ -155,7 +155,7 @@ else
     FULL_GODOT_NAME=Godot_v${GODOT_VERSION}-${GODOT_RELEASE_TYPE}_linux_${GODOT_SERVER_TYPE}
 fi
 
-# these are mutually exclusive - direct scenes cannot take a config file but they can 
+# these are mutually exclusive - direct scenes cannot take a config file but they can
 # have all those options set on the scene itself anyways
 if [ "$DIRECT_SCENE" != "false" ]; then
     RUN_OPTIONS="${DIRECT_SCENE}"
@@ -199,7 +199,7 @@ else
 fi
 
 # removing scene used to rebuild import files
-rm -rf ./addons/gut/.cli_add/__rebuilder.gd 
+rm -rf ./addons/gut/.cli_add/__rebuilder.gd
 rm -rf ./addons/gut/.cli_add/__rebuilder_scene.tscn
 
 rm -rf ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}


### PR DESCRIPTION
Attempted fix for GUT 7.3.0

From what I undertand of your script, you start checking for lines after you detect the summary. But the summary changed in 7.3.0

The old summary was:

```
 Totals
Scripts:          37
Tests:            551
Passing asserts:  4319
Failing asserts:  0
Pending:          8
```

Whereas the new one is:

```
 Totals
Scripts:          37
Passing tests     546
Failing tests     0
Pending:          8
Asserts:          4323/0
```

So the set of the `test_set` variable is never 1.

By matching against "Totals", it will more accurately detect the start of summary

Fixes #20 