### PR TITLE
add option for custom godot builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,10 @@ inputs:
     description: "Full path to your GUT config file, e.g. 'res://<path>/<config>.json'."
     required: false
     default: "res://.gutconfig.json"
+  custom-godot-dl-url:
+    description: "URL where a precompiled, custom Godot binary will be downloaded and used instead of an official Godot binary."
+    required: false
+    default: ""
 
 runs:
   using: 'docker'
@@ -71,6 +75,7 @@ runs:
   - ${{ inputs.max-fails }}
   - ${{ inputs.ignore-errors }}
   - ${{ inputs.config-file }}
+  - ${{ inputs.custom-godot-dl-url }}
 
 branding:
   icon: 'chevron-right'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,7 @@ ASSERT_CHECK=${10}
 MAX_FAILS=${11}
 IGNORE_ERROR=${12}
 CONFIG_FILE=${13}
+CUSTOM_GODOT_DL_URL=${14}
 
 GODOT_SERVER_TYPE="headless"
 TESTS=0
@@ -173,8 +174,13 @@ mv -n /__rebuilder_scene.tscn ./addons/gut/.cli_add
 # in case this was somehow there already, but broken
 rm -rf ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}
 rm -f ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME}${GODOT_EXTENSION}.zip
+
 # setup godot environment
 DL_URL="https://downloads.tuxfamily.org/godotengine/${DL_PATH_EXTENSION}${FULL_GODOT_NAME}${GODOT_EXTENSION}.zip"
+if [ "$CUSTOM_GODOT_DL_URL" != "" ]; then
+    DL_URL="$CUSTOM_GODOT_DL_URL"
+fi
+
 echo "downloading godot from ${DL_URL} ..."
 yes | wget -q ${DL_URL} -P ${CUSTOM_DL_PATH}
 mkdir -p ~/.cache


### PR DESCRIPTION
Adds an option for custom Godot builds to be used instead of the official binaries

[Seems to work](https://github.com/virtual-puppet-project/vpuppr/runs/7365917180?check_suite_focus=true) in my tests using a custom c++ singleton for null-safety.