### PR TITLE
add a job matrix, fix v4 mono

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -3,7 +3,7 @@ name: Build tester
 on: [pull_request, push]
 
 jobs:
-  build:
+  v4:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -14,11 +14,19 @@ jobs:
         minimum-pass: "0.6"
         test-dir: "res://test"
         config-file: "res://.gutconf.json"
+  v4-rc2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       with:
         version: "4.0.3"
         path: "tester_GUT_v9.0.1"
         release_type: "rc2"
+  v4-direct:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       with:
         version: "4.0.3"
@@ -27,6 +35,10 @@ jobs:
         direct-scene: "test/alt_mode/tests.tscn"
         result-output-file: "direct_scene_xml_output.xml"
         config-file: "res://.gutconf.json"
+  v4-direct-assert:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       with:
         version: "4.0.3"
@@ -36,7 +48,11 @@ jobs:
         direct-scene: "test/alt_mode/tests.tscn"
         result-output-file: "direct_scene_xml_output.xml"
         assert-check: "true"
-        max-fails: "6"
+        max-fails: "6"     
+  v4-rc2-assert:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       with:
         version: "4.0.3"
@@ -46,7 +62,11 @@ jobs:
         test-timeout: "45"
         minimum-pass: "0.7"
         assert-check: "false"
-        max-fails: "2"
+        max-fails: "2"  
+  v3:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       with:
         version: "3.2.1"
@@ -57,6 +77,10 @@ jobs:
         minimum-pass: "0.6"
         test-dir: "res://test"
         config-file: "res://.gutconf.json"
+  v3-2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       continue-on-error: true
       with:
@@ -64,7 +88,10 @@ jobs:
         path: "tester_GUT_v7.4.1"
         test-timeout: "2"
         minimum-pass: "0.7"
-        ignore-errors: "true"
+  v3-fail-80percent:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       continue-on-error: true
       with:
@@ -72,17 +99,29 @@ jobs:
         path: "tester_GUT_v7.4.1"
         test-timeout: "2"
         minimum-pass: "0.8"
+  v3-fail-100percent:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       continue-on-error: true
       with:
         version: "3.2.2"
         path: "tester_GUT_v7.4.1"
+  v3-rc2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       continue-on-error: true
       with:
         version: "3.4"
         release_type: "rc2"
         path: "tester_GUT_v7.4.1"
+  v3-direct:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       with:
         version: "3.2.2"
@@ -92,7 +131,10 @@ jobs:
         direct-scene: "test/alt_mode/tests.tscn"
         result-output-file: "direct_scene_xml_output.xml"
         config-file: "res://.gutconf.json"
-        ignore-errors: "true"
+  v3-direct-assert:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       with:
         version: "3.2.2"
@@ -102,6 +144,10 @@ jobs:
         direct-scene: "test/alt_mode/tests.tscn"
         result-output-file: "direct_scene_xml_output.xml"
         assert-check: "true"
+  v3-min70percent:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       continue-on-error: true
       with:
@@ -111,6 +157,10 @@ jobs:
         minimum-pass: "0.7"
         assert-check: "false"
         max-fails: "2"
+  v3-direct70percent:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: ./
       with:
         version: "3.2.2"

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -53,6 +53,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
     - uses: ./
       with:
         version: "4.0.3"
@@ -67,6 +70,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
     - uses: ./
       with:
         version: "3.2.1"
@@ -88,6 +94,7 @@ jobs:
         path: "tester_GUT_v7.4.1"
         test-timeout: "2"
         minimum-pass: "0.7"
+        import-time: "3"
   v3-fail-80percent:
     runs-on: ubuntu-latest
     steps:
@@ -99,6 +106,7 @@ jobs:
         path: "tester_GUT_v7.4.1"
         test-timeout: "2"
         minimum-pass: "0.8"
+        import-time: "3"
   v3-fail-100percent:
     runs-on: ubuntu-latest
     steps:
@@ -108,6 +116,7 @@ jobs:
       with:
         version: "3.2.2"
         path: "tester_GUT_v7.4.1"
+        import-time: "3"
   v3-rc2:
     runs-on: ubuntu-latest
     steps:
@@ -118,6 +127,7 @@ jobs:
         version: "3.4"
         release_type: "rc2"
         path: "tester_GUT_v7.4.1"
+        import-time: "3"
   v3-direct:
     runs-on: ubuntu-latest
     steps:
@@ -131,6 +141,7 @@ jobs:
         direct-scene: "test/alt_mode/tests.tscn"
         result-output-file: "direct_scene_xml_output.xml"
         config-file: "res://.gutconf.json"
+        import-time: "3"
   v3-direct-assert:
     runs-on: ubuntu-latest
     steps:
@@ -144,6 +155,7 @@ jobs:
         direct-scene: "test/alt_mode/tests.tscn"
         result-output-file: "direct_scene_xml_output.xml"
         assert-check: "true"
+        import-time: "3"
   v3-min70percent:
     runs-on: ubuntu-latest
     steps:
@@ -157,6 +169,7 @@ jobs:
         minimum-pass: "0.7"
         assert-check: "false"
         max-fails: "2"
+        import-time: "3"
   v3-direct70percent:
     runs-on: ubuntu-latest
     steps:
@@ -171,3 +184,4 @@ jobs:
         result-output-file: "direct_scene_xml_output.xml"
         assert-check: "true"
         max-fails: "6"
+        import-time: "3"

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -53,16 +53,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-    - run: dotnet restore
     - uses: ./
       with:
         version: "4.0.3"
         path: "tester_GUT_v9.0.1"
         release_type: "rc2"
         is-mono: "true"
+        test-timeout: "45"
+        import-time: "60"
         minimum-pass: "0.7"
         assert-check: "false"
         max-fails: "2"  

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -3,53 +3,53 @@ name: Build tester
 on: [pull_request, push]
 
 jobs:
-  # v4:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     with:
-  #       version: "4.0.3"
-  #       path: "tester_GUT_v9.0.1"
-  #       minimum-pass: "0.6"
-  #       test-dir: "res://test"
-  #       config-file: "res://.gutconf.json"
-  # v4-rc2:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     with:
-  #       version: "4.0.3"
-  #       path: "tester_GUT_v9.0.1"
-  #       release_type: "rc2"
-  # v4-direct:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     with:
-  #       version: "4.0.3"
-  #       path: "tester_GUT_v9.0.1"
-  #       minimum-pass: "0.6"
-  #       direct-scene: "test/alt_mode/tests.tscn"
-  #       result-output-file: "direct_scene_xml_output.xml"
-  #       config-file: "res://.gutconf.json"
-  # v4-direct-assert:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     with:
-  #       version: "4.0.3"
-  #       path: "tester_GUT_v9.0.1"
-  #       test-timeout: "45"
-  #       minimum-pass: "0.6"
-  #       direct-scene: "test/alt_mode/tests.tscn"
-  #       result-output-file: "direct_scene_xml_output.xml"
-  #       assert-check: "true"
-  #       max-fails: "6"     
-  v4-rc2-assert:
+  v4:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      with:
+        version: "4.0.3"
+        path: "tester_GUT_v9.0.1"
+        minimum-pass: "0.6"
+        test-dir: "res://test"
+        config-file: "res://.gutconf.json"
+  v4-rc2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      with:
+        version: "4.0.3"
+        path: "tester_GUT_v9.0.1"
+        release_type: "rc2"
+  v4-direct:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      with:
+        version: "4.0.3"
+        path: "tester_GUT_v9.0.1"
+        minimum-pass: "0.6"
+        direct-scene: "test/alt_mode/tests.tscn"
+        result-output-file: "direct_scene_xml_output.xml"
+        config-file: "res://.gutconf.json"
+  v4-direct-assert:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      with:
+        version: "4.0.3"
+        path: "tester_GUT_v9.0.1"
+        test-timeout: "45"
+        minimum-pass: "0.6"
+        direct-scene: "test/alt_mode/tests.tscn"
+        result-output-file: "direct_scene_xml_output.xml"
+        assert-check: "true"
+        max-fails: "6"     
+  v4-mono:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -60,123 +60,123 @@ jobs:
         release_type: "rc2"
         is-mono: "true"
         test-timeout: "45"
-        import-time: "60"
+        import-time: "25"
         minimum-pass: "0.7"
         assert-check: "false"
         max-fails: "2"  
-  # v3:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     with:
-  #       version: "3.2.1"
-  #       is-mono: "true"
-  #       path: "tester_GUT_v7.4.1"
-  #       import-time: "5"
-  #       test-timeout: "45"
-  #       minimum-pass: "0.6"
-  #       test-dir: "res://test"
-  #       config-file: "res://.gutconf.json"
-  # v3-2:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     continue-on-error: true
-  #     with:
-  #       version: "3.2.2"
-  #       path: "tester_GUT_v7.4.1"
-  #       test-timeout: "2"
-  #       minimum-pass: "0.7"
-  #       import-time: "3"
-  # v3-fail-80percent:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     continue-on-error: true
-  #     with:
-  #       version: "3.2.2"
-  #       path: "tester_GUT_v7.4.1"
-  #       test-timeout: "2"
-  #       minimum-pass: "0.8"
-  #       import-time: "3"
-  # v3-fail-100percent:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     continue-on-error: true
-  #     with:
-  #       version: "3.2.2"
-  #       path: "tester_GUT_v7.4.1"
-  #       import-time: "3"
-  # v3-rc2:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     continue-on-error: true
-  #     with:
-  #       version: "3.4"
-  #       release_type: "rc2"
-  #       path: "tester_GUT_v7.4.1"
-  #       import-time: "3"
-  # v3-direct:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     with:
-  #       version: "3.2.2"
-  #       path: "tester_GUT_v7.4.1"
-  #       test-timeout: "45"
-  #       minimum-pass: "0.7"
-  #       direct-scene: "test/alt_mode/tests.tscn"
-  #       result-output-file: "direct_scene_xml_output.xml"
-  #       config-file: "res://.gutconf.json"
-  #       import-time: "3"
-  # v3-direct-assert:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     with:
-  #       version: "3.2.2"
-  #       path: "tester_GUT_v7.4.1"
-  #       test-timeout: "45"
-  #       minimum-pass: "0.7"
-  #       direct-scene: "test/alt_mode/tests.tscn"
-  #       result-output-file: "direct_scene_xml_output.xml"
-  #       assert-check: "true"
-  #       import-time: "3"
-  # v3-min70percent:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     continue-on-error: true
-  #     with:
-  #       version: "3.2.2"
-  #       path: "tester_GUT_v7.4.1"
-  #       test-timeout: "45"
-  #       minimum-pass: "0.7"
-  #       assert-check: "false"
-  #       max-fails: "2"
-  #       import-time: "3"
-  # v3-direct70percent:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: ./
-  #     with:
-  #       version: "3.2.2"
-  #       path: "tester_GUT_v7.4.1"
-  #       test-timeout: "45"
-  #       minimum-pass: "0.7"
-  #       direct-scene: "test/alt_mode/tests.tscn"
-  #       result-output-file: "direct_scene_xml_output.xml"
-  #       assert-check: "true"
-  #       max-fails: "6"
-  #       import-time: "3"
+  v3-mono:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      with:
+        version: "3.2.1"
+        is-mono: "true"
+        path: "tester_GUT_v7.4.1"
+        import-time: "5"
+        test-timeout: "45"
+        minimum-pass: "0.6"
+        test-dir: "res://test"
+        config-file: "res://.gutconf.json"
+  v3-2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      continue-on-error: true
+      with:
+        version: "3.2.2"
+        path: "tester_GUT_v7.4.1"
+        test-timeout: "2"
+        minimum-pass: "0.7"
+        import-time: "3"
+  v3-fail-80percent:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      continue-on-error: true
+      with:
+        version: "3.2.2"
+        path: "tester_GUT_v7.4.1"
+        test-timeout: "2"
+        minimum-pass: "0.8"
+        import-time: "3"
+  v3-fail-100percent:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      continue-on-error: true
+      with:
+        version: "3.2.2"
+        path: "tester_GUT_v7.4.1"
+        import-time: "3"
+  v3-rc2:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      continue-on-error: true
+      with:
+        version: "3.4"
+        release_type: "rc2"
+        path: "tester_GUT_v7.4.1"
+        import-time: "3"
+  v3-direct:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      with:
+        version: "3.2.2"
+        path: "tester_GUT_v7.4.1"
+        test-timeout: "45"
+        minimum-pass: "0.7"
+        direct-scene: "test/alt_mode/tests.tscn"
+        result-output-file: "direct_scene_xml_output.xml"
+        config-file: "res://.gutconf.json"
+        import-time: "3"
+  v3-direct-assert:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      with:
+        version: "3.2.2"
+        path: "tester_GUT_v7.4.1"
+        test-timeout: "45"
+        minimum-pass: "0.7"
+        direct-scene: "test/alt_mode/tests.tscn"
+        result-output-file: "direct_scene_xml_output.xml"
+        assert-check: "true"
+        import-time: "3"
+  v3-min70percent:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      continue-on-error: true
+      with:
+        version: "3.2.2"
+        path: "tester_GUT_v7.4.1"
+        test-timeout: "45"
+        minimum-pass: "0.7"
+        assert-check: "false"
+        max-fails: "2"
+        import-time: "3"
+  v3-direct70percent:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./
+      with:
+        version: "3.2.2"
+        path: "tester_GUT_v7.4.1"
+        test-timeout: "45"
+        minimum-pass: "0.7"
+        direct-scene: "test/alt_mode/tests.tscn"
+        result-output-file: "direct_scene_xml_output.xml"
+        assert-check: "true"
+        max-fails: "6"
+        import-time: "3"

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -3,52 +3,52 @@ name: Build tester
 on: [pull_request, push]
 
 jobs:
-  v4:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      with:
-        version: "4.0.3"
-        path: "tester_GUT_v9.0.1"
-        minimum-pass: "0.6"
-        test-dir: "res://test"
-        config-file: "res://.gutconf.json"
-  v4-rc2:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      with:
-        version: "4.0.3"
-        path: "tester_GUT_v9.0.1"
-        release_type: "rc2"
-  v4-direct:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      with:
-        version: "4.0.3"
-        path: "tester_GUT_v9.0.1"
-        minimum-pass: "0.6"
-        direct-scene: "test/alt_mode/tests.tscn"
-        result-output-file: "direct_scene_xml_output.xml"
-        config-file: "res://.gutconf.json"
-  v4-direct-assert:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      with:
-        version: "4.0.3"
-        path: "tester_GUT_v9.0.1"
-        test-timeout: "45"
-        minimum-pass: "0.6"
-        direct-scene: "test/alt_mode/tests.tscn"
-        result-output-file: "direct_scene_xml_output.xml"
-        assert-check: "true"
-        max-fails: "6"     
+  # v4:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     with:
+  #       version: "4.0.3"
+  #       path: "tester_GUT_v9.0.1"
+  #       minimum-pass: "0.6"
+  #       test-dir: "res://test"
+  #       config-file: "res://.gutconf.json"
+  # v4-rc2:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     with:
+  #       version: "4.0.3"
+  #       path: "tester_GUT_v9.0.1"
+  #       release_type: "rc2"
+  # v4-direct:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     with:
+  #       version: "4.0.3"
+  #       path: "tester_GUT_v9.0.1"
+  #       minimum-pass: "0.6"
+  #       direct-scene: "test/alt_mode/tests.tscn"
+  #       result-output-file: "direct_scene_xml_output.xml"
+  #       config-file: "res://.gutconf.json"
+  # v4-direct-assert:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     with:
+  #       version: "4.0.3"
+  #       path: "tester_GUT_v9.0.1"
+  #       test-timeout: "45"
+  #       minimum-pass: "0.6"
+  #       direct-scene: "test/alt_mode/tests.tscn"
+  #       result-output-file: "direct_scene_xml_output.xml"
+  #       assert-check: "true"
+  #       max-fails: "6"     
   v4-rc2-assert:
     runs-on: ubuntu-latest
     steps:
@@ -56,132 +56,129 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
+    - run: dotnet restore
     - uses: ./
       with:
         version: "4.0.3"
         path: "tester_GUT_v9.0.1"
         release_type: "rc2"
         is-mono: "true"
-        test-timeout: "45"
         minimum-pass: "0.7"
         assert-check: "false"
         max-fails: "2"  
-  v3:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-    - uses: ./
-      with:
-        version: "3.2.1"
-        is-mono: "true"
-        path: "tester_GUT_v7.4.1"
-        import-time: "5"
-        test-timeout: "45"
-        minimum-pass: "0.6"
-        test-dir: "res://test"
-        config-file: "res://.gutconf.json"
-  v3-2:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      continue-on-error: true
-      with:
-        version: "3.2.2"
-        path: "tester_GUT_v7.4.1"
-        test-timeout: "2"
-        minimum-pass: "0.7"
-        import-time: "3"
-  v3-fail-80percent:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      continue-on-error: true
-      with:
-        version: "3.2.2"
-        path: "tester_GUT_v7.4.1"
-        test-timeout: "2"
-        minimum-pass: "0.8"
-        import-time: "3"
-  v3-fail-100percent:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      continue-on-error: true
-      with:
-        version: "3.2.2"
-        path: "tester_GUT_v7.4.1"
-        import-time: "3"
-  v3-rc2:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      continue-on-error: true
-      with:
-        version: "3.4"
-        release_type: "rc2"
-        path: "tester_GUT_v7.4.1"
-        import-time: "3"
-  v3-direct:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      with:
-        version: "3.2.2"
-        path: "tester_GUT_v7.4.1"
-        test-timeout: "45"
-        minimum-pass: "0.7"
-        direct-scene: "test/alt_mode/tests.tscn"
-        result-output-file: "direct_scene_xml_output.xml"
-        config-file: "res://.gutconf.json"
-        import-time: "3"
-  v3-direct-assert:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      with:
-        version: "3.2.2"
-        path: "tester_GUT_v7.4.1"
-        test-timeout: "45"
-        minimum-pass: "0.7"
-        direct-scene: "test/alt_mode/tests.tscn"
-        result-output-file: "direct_scene_xml_output.xml"
-        assert-check: "true"
-        import-time: "3"
-  v3-min70percent:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      continue-on-error: true
-      with:
-        version: "3.2.2"
-        path: "tester_GUT_v7.4.1"
-        test-timeout: "45"
-        minimum-pass: "0.7"
-        assert-check: "false"
-        max-fails: "2"
-        import-time: "3"
-  v3-direct70percent:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ./
-      with:
-        version: "3.2.2"
-        path: "tester_GUT_v7.4.1"
-        test-timeout: "45"
-        minimum-pass: "0.7"
-        direct-scene: "test/alt_mode/tests.tscn"
-        result-output-file: "direct_scene_xml_output.xml"
-        assert-check: "true"
-        max-fails: "6"
-        import-time: "3"
+  # v3:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     with:
+  #       version: "3.2.1"
+  #       is-mono: "true"
+  #       path: "tester_GUT_v7.4.1"
+  #       import-time: "5"
+  #       test-timeout: "45"
+  #       minimum-pass: "0.6"
+  #       test-dir: "res://test"
+  #       config-file: "res://.gutconf.json"
+  # v3-2:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     continue-on-error: true
+  #     with:
+  #       version: "3.2.2"
+  #       path: "tester_GUT_v7.4.1"
+  #       test-timeout: "2"
+  #       minimum-pass: "0.7"
+  #       import-time: "3"
+  # v3-fail-80percent:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     continue-on-error: true
+  #     with:
+  #       version: "3.2.2"
+  #       path: "tester_GUT_v7.4.1"
+  #       test-timeout: "2"
+  #       minimum-pass: "0.8"
+  #       import-time: "3"
+  # v3-fail-100percent:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     continue-on-error: true
+  #     with:
+  #       version: "3.2.2"
+  #       path: "tester_GUT_v7.4.1"
+  #       import-time: "3"
+  # v3-rc2:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     continue-on-error: true
+  #     with:
+  #       version: "3.4"
+  #       release_type: "rc2"
+  #       path: "tester_GUT_v7.4.1"
+  #       import-time: "3"
+  # v3-direct:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     with:
+  #       version: "3.2.2"
+  #       path: "tester_GUT_v7.4.1"
+  #       test-timeout: "45"
+  #       minimum-pass: "0.7"
+  #       direct-scene: "test/alt_mode/tests.tscn"
+  #       result-output-file: "direct_scene_xml_output.xml"
+  #       config-file: "res://.gutconf.json"
+  #       import-time: "3"
+  # v3-direct-assert:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     with:
+  #       version: "3.2.2"
+  #       path: "tester_GUT_v7.4.1"
+  #       test-timeout: "45"
+  #       minimum-pass: "0.7"
+  #       direct-scene: "test/alt_mode/tests.tscn"
+  #       result-output-file: "direct_scene_xml_output.xml"
+  #       assert-check: "true"
+  #       import-time: "3"
+  # v3-min70percent:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     continue-on-error: true
+  #     with:
+  #       version: "3.2.2"
+  #       path: "tester_GUT_v7.4.1"
+  #       test-timeout: "45"
+  #       minimum-pass: "0.7"
+  #       assert-check: "false"
+  #       max-fails: "2"
+  #       import-time: "3"
+  # v3-direct70percent:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: ./
+  #     with:
+  #       version: "3.2.2"
+  #       path: "tester_GUT_v7.4.1"
+  #       test-timeout: "45"
+  #       minimum-pass: "0.7"
+  #       direct-scene: "test/alt_mode/tests.tscn"
+  #       result-output-file: "direct_scene_xml_output.xml"
+  #       assert-check: "true"
+  #       max-fails: "6"
+  #       import-time: "3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM croconut/linux-downloader
+RUN apt install dotnet-sdk-6.0
 
 COPY test_runner_lib /test_runner_lib
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM croconut/linux-downloader
-RUN apt install dotnet-sdk-6.0
+RUN apt-get update && apt-get install -y dotnet-sdk-6.0
 
 COPY test_runner_lib /test_runner_lib
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     dotnet-sdk-6.0 \
     wget \
-    unzip \
-    cut
+    unzip
 
 COPY test_runner_lib /test_runner_lib
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y 
+RUN apt-get update && apt-get install -y \
+    dotnet-sdk-6.0 \
+    wget
 
 COPY test_runner_lib /test_runner_lib
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     dotnet-sdk-6.0 \
     wget \
-    unzip
+    unzip \
+    fontconfig
 
 COPY test_runner_lib /test_runner_lib
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
     dotnet-sdk-6.0 \
-    wget
+    wget \
+    unzip \
+    cut
 
 COPY test_runner_lib /test_runner_lib
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update && apt-get install -y \
     dotnet-sdk-6.0 \
     wget \
     unzip \
-    fontconfig
+    fontconfig \
+    bc
 
 COPY test_runner_lib /test_runner_lib
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM croconut/linux-downloader
+RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+ && dpkg -i packages-microsoft-prod.deb \
+ && packages-microsoft-prod.deb
+
 RUN apt-get update && apt-get install -y dotnet-sdk-6.0
 
 COPY test_runner_lib /test_runner_lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM croconut/linux-downloader
-RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
- && dpkg -i packages-microsoft-prod.deb \
- && packages-microsoft-prod.deb
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y dotnet-sdk-6.0
+RUN apt-get update && apt-get install -y 
 
 COPY test_runner_lib /test_runner_lib
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: croconut/godot-tester@v4
+    - uses: croconut/godot-tester@v4.1
       with:
         # required
         version: "4.0.3"

--- a/test_runner_lib/functions.sh
+++ b/test_runner_lib/functions.sh
@@ -250,7 +250,7 @@ run_tests() {
     # this argument on v3.x is simply ignored
     echo "running imports ..."
     
-    timeout ${IMPORT_TIME} "${GODOT_EXECUTABLE} --headless --editor addons/gut/.cli_add/__rebuilder_scene.tscn"
+    timeout ${IMPORT_TIME} "${GODOT_EXECUTABLE}" --headless --editor addons/gut/.cli_add/__rebuilder_scene.tscn
     # After the imports are done, we can run the tests
     echo "running tests ..."
     timeout ${TEST_TIME} "${GODOT_EXECUTABLE}" ${RUN_OPTIONS}

--- a/test_runner_lib/functions.sh
+++ b/test_runner_lib/functions.sh
@@ -18,6 +18,12 @@ check_if_version_four() {
     fi
 }
 
+create_mono_folder() {
+    if [ "$IS_MONO" = "true" ]; then
+        mkdir /home/user/.local/share/godot/mono/GodotNuGetFallbackFolder
+    fi
+}
+
 delete_godot() {
     rm -rf ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME_EXT}
     rm -f ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME_EXT}.zip
@@ -118,7 +124,6 @@ download_godot() {
 
 generate_run_options() {
     RUN_OPTIONS="-s addons/gut/gut_cmdln.gd"
-    IMPORT_RUN_OPTIONS="--headless --editor"
     RUN_OPTIONS="${RUN_OPTIONS} -gdir=${TEST_DIR}"
     RUN_OPTIONS="${RUN_OPTIONS} -ginclude_subdirs"
     RUN_OPTIONS="${RUN_OPTIONS} -gjunit_xml_file=./${RESULT_OUTPUT_FILE}"
@@ -137,12 +142,7 @@ generate_run_options() {
         # you must use the --headless argument 
         # rather than use a headless binary
         RUN_OPTIONS="${RUN_OPTIONS} --headless"
-    fi
-
-
-    if [ "$IS_MONO" = "true" ]; then
-        IMPORT_RUN_OPTIONS="${IMPORT_RUN_OPTIONS} --generate-mono-glue modules/mono/glue"
-    fi  
+    fi 
 }
 
 check_by_test() {
@@ -250,7 +250,7 @@ run_tests() {
     # this argument on v3.x is simply ignored
     echo "running imports ..."
     
-    timeout ${IMPORT_TIME} "${GODOT_EXECUTABLE} ${IMPORT_RUN_OPTIONS} addons/gut/.cli_add/__rebuilder_scene.tscn"
+    timeout ${IMPORT_TIME} "${GODOT_EXECUTABLE} --headless --editor addons/gut/.cli_add/__rebuilder_scene.tscn"
     # After the imports are done, we can run the tests
     echo "running tests ..."
     timeout ${TEST_TIME} "${GODOT_EXECUTABLE}" ${RUN_OPTIONS}

--- a/test_runner_lib/functions.sh
+++ b/test_runner_lib/functions.sh
@@ -118,6 +118,7 @@ download_godot() {
 
 generate_run_options() {
     RUN_OPTIONS="-s addons/gut/gut_cmdln.gd"
+    IMPORT_RUN_OPTIONS="--headless --editor"
     RUN_OPTIONS="${RUN_OPTIONS} -gdir=${TEST_DIR}"
     RUN_OPTIONS="${RUN_OPTIONS} -ginclude_subdirs"
     RUN_OPTIONS="${RUN_OPTIONS} -gjunit_xml_file=./${RESULT_OUTPUT_FILE}"
@@ -137,6 +138,11 @@ generate_run_options() {
         # rather than use a headless binary
         RUN_OPTIONS="${RUN_OPTIONS} --headless"
     fi
+
+
+    if [ "$IS_MONO" = "true" ]; then
+        IMPORT_RUN_OPTIONS="${IMPORT_RUN_OPTIONS} --generate-mono-glue modules/mono/glue"
+    fi  
 }
 
 check_by_test() {
@@ -243,7 +249,8 @@ run_tests() {
     # Added --headless to the import step to account for v4+ behavior
     # this argument on v3.x is simply ignored
     echo "running imports ..."
-    timeout ${IMPORT_TIME} "${GODOT_EXECUTABLE}" --headless --editor addons/gut/.cli_add/__rebuilder_scene.tscn
+    
+    timeout ${IMPORT_TIME} "${GODOT_EXECUTABLE} ${IMPORT_RUN_OPTIONS} addons/gut/.cli_add/__rebuilder_scene.tscn"
     # After the imports are done, we can run the tests
     echo "running tests ..."
     timeout ${TEST_TIME} "${GODOT_EXECUTABLE}" ${RUN_OPTIONS}

--- a/test_runner_lib/functions.sh
+++ b/test_runner_lib/functions.sh
@@ -18,12 +18,6 @@ check_if_version_four() {
     fi
 }
 
-create_mono_folder() {
-    if [ "$IS_MONO" = "true" ]; then
-        mkdir /home/user/.local/share/godot/mono/GodotNuGetFallbackFolder
-    fi
-}
-
 delete_godot() {
     rm -rf ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME_EXT}
     rm -f ${CUSTOM_DL_PATH}/${FULL_GODOT_NAME_EXT}.zip
@@ -142,7 +136,7 @@ generate_run_options() {
         # you must use the --headless argument 
         # rather than use a headless binary
         RUN_OPTIONS="${RUN_OPTIONS} --headless"
-    fi 
+    fi
 }
 
 check_by_test() {
@@ -249,7 +243,6 @@ run_tests() {
     # Added --headless to the import step to account for v4+ behavior
     # this argument on v3.x is simply ignored
     echo "running imports ..."
-    
     timeout ${IMPORT_TIME} "${GODOT_EXECUTABLE}" --headless --editor addons/gut/.cli_add/__rebuilder_scene.tscn
     # After the imports are done, we can run the tests
     echo "running tests ..."


### PR DESCRIPTION
resolves #29 

the test matrix change is just: moving everything to its own job - a normal GH Action matrix doesnt work well due to a matrix running every parameter combination.

the mono fix is due to the docker image not having the .net 6 sdk

@RGonzalezTech i'd recommend immediately patching the 4.0 release so that mono will correctly work. the mono errors were being covered up by the way the single job tests were being run.