### PR TITLE
chore: Use Node 20 and `checkout@v4`

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
       - run: npm ci
       - run: npm test

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -6,7 +6,7 @@ jobs:
   v4:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         version: "4.0.3"
@@ -17,7 +17,7 @@ jobs:
   v4-rc2:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         version: "4.0.3"
@@ -26,7 +26,7 @@ jobs:
   v4-direct:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         version: "4.0.3"
@@ -38,7 +38,7 @@ jobs:
   v4-direct-assert:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         version: "4.0.3"
@@ -52,7 +52,7 @@ jobs:
   v4-mono:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         version: "4.0.3"
@@ -67,7 +67,7 @@ jobs:
   v3-mono:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         version: "3.2.1"
@@ -81,7 +81,7 @@ jobs:
   v3-2:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       continue-on-error: true
       with:
@@ -93,7 +93,7 @@ jobs:
   v3-fail-80percent:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       continue-on-error: true
       with:
@@ -105,7 +105,7 @@ jobs:
   v3-fail-100percent:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       continue-on-error: true
       with:
@@ -115,7 +115,7 @@ jobs:
   v3-rc2:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       continue-on-error: true
       with:
@@ -126,7 +126,7 @@ jobs:
   v3-direct:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         version: "3.2.2"
@@ -140,7 +140,7 @@ jobs:
   v3-direct-assert:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         version: "3.2.2"
@@ -154,7 +154,7 @@ jobs:
   v3-min70percent:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       continue-on-error: true
       with:
@@ -168,7 +168,7 @@ jobs:
   v3-direct70percent:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         version: "3.2.2"

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -6,7 +6,7 @@ jobs:
   v4:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         version: "4.0.3"
@@ -17,7 +17,7 @@ jobs:
   v4-rc2:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         version: "4.0.3"
@@ -26,7 +26,7 @@ jobs:
   v4-direct:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         version: "4.0.3"
@@ -38,7 +38,7 @@ jobs:
   v4-direct-assert:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         version: "4.0.3"
@@ -48,11 +48,11 @@ jobs:
         direct-scene: "test/alt_mode/tests.tscn"
         result-output-file: "direct_scene_xml_output.xml"
         assert-check: "true"
-        max-fails: "6"     
+        max-fails: "6"
   v4-mono:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         version: "4.0.3"
@@ -63,11 +63,11 @@ jobs:
         import-time: "25"
         minimum-pass: "0.7"
         assert-check: "false"
-        max-fails: "2"  
+        max-fails: "2"
   v3-mono:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         version: "3.2.1"
@@ -81,7 +81,7 @@ jobs:
   v3-2:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       continue-on-error: true
       with:
@@ -93,7 +93,7 @@ jobs:
   v3-fail-80percent:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       continue-on-error: true
       with:
@@ -105,7 +105,7 @@ jobs:
   v3-fail-100percent:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       continue-on-error: true
       with:
@@ -115,7 +115,7 @@ jobs:
   v3-rc2:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       continue-on-error: true
       with:
@@ -126,7 +126,7 @@ jobs:
   v3-direct:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         version: "3.2.2"
@@ -140,7 +140,7 @@ jobs:
   v3-direct-assert:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         version: "3.2.2"
@@ -154,7 +154,7 @@ jobs:
   v3-min70percent:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       continue-on-error: true
       with:
@@ -168,7 +168,7 @@ jobs:
   v3-direct70percent:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ./
       with:
         version: "3.2.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,7 @@
-FROM ubuntu:22.04
+FROM docker.io/node:20-bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV NODE_ENV=production
-
-# prepare apt with node 20.x
-RUN apt-get update && apt-get install -y \
-    curl \
-    gnupg \
-    lsb-release \
-    dotnet-sdk-6.0 \
-    wget \
-    unzip \
-    fontconfig \
-    bc
-
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
-RUN apt-get update && apt-get install -y nodejs
 
 COPY lib /lib
 COPY package.json /package.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,31 @@
-FROM docker.io/node:20-bookworm-slim
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV NODE_ENV=production
+
+# prepare apt with node 16.x
+RUN apt-get update && apt-get install -y \
+    curl \
+    gnupg \
+    lsb-release \
+    dotnet-sdk-6.0 \
+    wget \
+    unzip \
+    fontconfig \
+    bc \
+    ca-certificates
+
+# Install NodeJS
+# https://stackoverflow.com/a/77021599
+RUN set -uex; \
+    mkdir -p /etc/apt/keyrings; \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+     | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
+    NODE_MAJOR=20; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+     > /etc/apt/sources.list.d/nodesource.list; \
+    apt-get update; \
+    apt-get install nodejs -y;
 
 COPY lib /lib
 COPY package.json /package.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV NODE_ENV=production
 
-# prepare apt with node 16.x
+# prepare apt with node 20.x
 RUN apt-get update && apt-get install -y \
     curl \
     gnupg \
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     fontconfig \
     bc
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 
 COPY lib /lib


### PR DESCRIPTION
This PR updates godot-tester to use Node 20 and checkout@v4. This primarily serves to avoid using deprecated components, but it also speeds up CI times considerably by avoiding [a needless 60 second wait](https://github.com/rainbowcow-studio/farmhand-shuffle/actions/runs/6327316140/job/17182862771#step:2:544).